### PR TITLE
gamut mapping via oklch.c

### DIFF
--- a/app.css
+++ b/app.css
@@ -20,7 +20,7 @@ body {
 
 #app > div {
 	padding: 0.2em;
-	background-color: var(--colorjs-lch-6);
+	background-color: rgb(63, 63, 63);
 	text-align: center;
 	display: grid;
 	place-items: center;
@@ -38,5 +38,5 @@ body {
 
 #app > .tab {
 	font-variant-numeric: tabular-nums;
-	background-color: var(--colorjs-lch-4);
+	background-color: rgb(63, 63, 63);
 }

--- a/app.js
+++ b/app.js
@@ -77,7 +77,7 @@ const style = async () => {
 			let value
 
 			if (tokens[0] === 'colorjs') {
-				value = color.toString()
+				value = color.clone().toGamut({space: "p3", method: "oklch.c"}).to("p3").toString()
 			} else {
 				value = color.to(tokens[1]).toString()
 			}


### PR DESCRIPTION
`postcss` color fallback plugins use `oklch.c` as the gamut mapping method.
If I update the Color.JS related code to use this method the results become very similar.

I also changed the surroundings to a flat grey as the blue was influencing how I perceived the darker and lower chroma items.

_this PR is not really intended to be merged, just a tool to communicate_

<img width="611" alt="Screenshot 2022-07-30 at 10 31 47" src="https://user-images.githubusercontent.com/11521496/181900026-27032ea7-350d-4b53-a8e8-9ab7643cdff1.png">
